### PR TITLE
Adding Dockerfile to build docker image of depthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ This is the source of the http://depthy.me/ webapp. Contributions more than welc
 - For local development server run: `grunt serve`
 - For deployment: `grunt build`
 
+## Docker image
+If you want to simply run depthy locally, you can use [Docker.io](https://www.docker.com/).
+
+Once docker installed, simple run:
+```
+$ docker run --rm -t -i -p 9000:9000 essembeh/depthy
+```
+
+Then go to [localhost:9000](http://localhost:9000)
+
 ## Authors
 
 **[Rafał Lindemann](http://www.stamina.pl/)** (idea, code, ux) with much appreciated help of

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:trusty
+MAINTAINER Sébastien M-B <essembeh@gmail.com>
+
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8
+
+ADD sources.list /etc/apt/
+
+RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y nodejs npm ruby-compass
+
+RUN ln -s /usr/bin/nodejs /usr/bin/node
+RUN npm install -g grunt-cli bower
+
+RUN git clone https://github.com/panrafal/depthy.git
+WORKDIR /depthy
+RUN npm install
+RUN bower install --allow-root --config.interactive=false
+
+EXPOSE 9000 
+ENTRYPOINT grunt serve
+

--- a/docker/sources.list
+++ b/docker/sources.list
@@ -1,0 +1,5 @@
+deb http://archive.ubuntu.com/ubuntu trusty main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu trusty-security main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu trusty-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse
+


### PR DESCRIPTION
Dockerfile + documentation.

As presented in #18, if the dockerfile and the code are in the same github repository, it is possible to automatically build a docker image every time you commit.

See https://docs.docker.com/docker-hub/builds/ for more documentation.