### PR TITLE
Update Dockerhub image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to simply run depthy locally, you can use [Docker.io](https://www.do
 
 Once docker installed, simple run:
 ```
-$ docker run --rm -t -i -p 9000:9000 essembeh/depthy
+$ docker run --rm -t -i -p 9000:9000 ndahlquist/depthy
 ```
 
 Then go to [localhost:9000](http://localhost:9000)


### PR DESCRIPTION
It seems that https://hub.docker.com/r/essembeh/depthy doesn't exist anymore. I've made a new Docker image and uploaded it here.

Note: Some code changes were necessary to get the Dockerfile to function correctly, since dependencies have changed over the last few years. I'll make a [separate PR](https://github.com/panrafal/depthy/pull/49) for that, because I'm not sure if you'll want those changes.